### PR TITLE
Simplifica logica de formulare

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "jsx": true,
     "classes": true,
     "modules": true,
+    "no-underscore-dangle": false,
     "global-strict": 0,
     "react/display-name": 1,
     "react/jsx-quotes": 1,

--- a/src/components/register-in-contest.jsx
+++ b/src/components/register-in-contest.jsx
@@ -108,7 +108,7 @@ export default React.createClass({
   renderFormOrMessage(renderForm, formId) {
     if (formId < this.props.user.registration_step_number) {
       return this.renderSuccess();
-    } else if (formId == this.props.user.registration_step_number) {
+    } else if (formId === this.props.user.registration_step_number) {
       return renderForm();
     } else {
       return this.renderUnavailableStep();

--- a/src/components/register-in-contest.jsx
+++ b/src/components/register-in-contest.jsx
@@ -26,7 +26,7 @@ export default React.createClass({
           id: 0,
           title: ""
         },
-        projects: []
+        finished_projects: []
       }
     };
   },
@@ -152,16 +152,14 @@ export default React.createClass({
   },
 
   renderRegisteredProjects() {
-    if (!this.props.registration.projects.length) {
+    if (!this.props.registration.finished_projects.length) {
       return <p>Nu ai niciun proiect înscris.</p>;
     }
     return <div>
       <p>Proiectele inscrise de tine până acum:</p>
       <ul>
-        {this.props.registration.projects.map((project) => {
-          if (project.finished) {
-            return <li key={project.id}>{project.title}</li>;
-          }
+        {this.props.registration.finished_projects.map((project) => {
+          return <li key={project.id}>{project.title}</li>;
         })}
       </ul>
     </div>;

--- a/src/components/register-in-contest.jsx
+++ b/src/components/register-in-contest.jsx
@@ -162,6 +162,8 @@ export default React.createClass({
           return <li key={project.id}>{project.title}</li>;
         })}
       </ul>
+      <p>Proiectele vor trebui să fie aprobate ca să apară în secțiunea de
+      participanți</p>
     </div>;
   },
 

--- a/src/components/register-in-contest.jsx
+++ b/src/components/register-in-contest.jsx
@@ -107,7 +107,7 @@ export default React.createClass({
 
   renderFormOrMessage(renderForm, formId) {
     if (formId < this.props.user.registration_step_number) {
-      return this.renderSuccess();
+      return this.renderSuccessStep();
     }
     if (formId === this.props.user.registration_step_number) {
       return renderForm();
@@ -115,7 +115,7 @@ export default React.createClass({
     return this.renderUnavailableStep();
   },
 
-  renderSuccess() {
+  renderSuccessStep() {
     return <div className="success">
       Ai terminat acest pas cu succes.
     </div>;

--- a/src/components/register-in-contest.jsx
+++ b/src/components/register-in-contest.jsx
@@ -108,11 +108,11 @@ export default React.createClass({
   renderFormOrMessage(renderForm, formId) {
     if (formId < this.props.user.registration_step_number) {
       return this.renderSuccess();
-    } else if (formId === this.props.user.registration_step_number) {
-      return renderForm();
-    } else {
-      return this.renderUnavailableStep();
     }
+    if (formId === this.props.user.registration_step_number) {
+      return renderForm();
+    }
+    return this.renderUnavailableStep();
   },
 
   renderSuccess() {

--- a/src/components/register-in-contest/register-contestant.jsx
+++ b/src/components/register-in-contest/register-contestant.jsx
@@ -289,10 +289,10 @@ export default React.createClass({
       method: "POST",
       url: window.config.API_URL + "contestants.json",
       headers: {
-        Authorization: this.props.current.user.access_token
+        Authorization: this.props.access_token
       },
       data: data,
-      success: this.props.hasSubmited,
+      success: this.props.onSubmit,
       error: this.onRequestError
     });
   },

--- a/src/components/register-in-contest/register-finish.jsx
+++ b/src/components/register-in-contest/register-finish.jsx
@@ -15,7 +15,7 @@ export default React.createClass({
   render() {
     return <form onSubmit={this.onFormSubmit}>
       <p>Trimite proiectul tău&nbsp;
-      <em>{this.props.current.registration.pending_project.title}</em>.</p>
+      <em>{this.props.pending_project_title}</em>.</p>
       <ButtonInput type="submit"
                    value="Termină"
                    disabled={this.state.waitingForServerResponse} />

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -39,9 +39,6 @@ let App = React.createClass({
           total_participants: 0,
           total_projects: 0,
           total_counties: 0
-        },
-        registration: {
-          has_contestant: false
         }
       }
     };
@@ -62,6 +59,8 @@ let App = React.createClass({
   render() {
     return <div className="main">
       <RouteHandler current={this.state.current}
+                    user={this.state.current.user}
+                    registration={this.state.current.registration}
                     refreshCurrent={this.getCurrent}
                     isLoggedIn={this.state.isLoggedIn}
                     login={this.login}

--- a/src/mixins/form.jsx
+++ b/src/mixins/form.jsx
@@ -51,10 +51,10 @@ export default {
       method: "POST",
       url: window.config.API_URL + this.props.formEndpoint,
       headers: {
-        Authorization: this.props.current.user.access_token
+        Authorization: this.props.access_token
       },
       data: data,
-      success: this.props.hasSubmited,
+      success: this.props.onSubmit,
       error: this.onRequestError
     });
   },


### PR DESCRIPTION
O să avem un field pe user pus `registration_step_number` care by default e 1. De fiecare data cand se va face un POST, controllerul unde s-a facut e responsabil cu incrementarea numarului astuia. Assignam un numar la fiecare formular:
1. contestant
2. project
3. additional
4. screenshot
5. finish

Si la 6 sunt toate verzi.

Daca numarul formularului e mai mic ca `registration_step_number` care vine din current, atunci apare formular trimis. Daca e mai mare, apare mesajul ca trebuie sa faci pasul de dinainte, altfel formularul e deschis.

Daca sunt in starea 6, mai am undeva un buton de adaugare proiect nou. Asta pune `registration_step_number` pe 2 si refolosesc intreg codul.

Venita într-un vis.
