### PR TITLE
Seminariile din anii anteriori si mai multi speakeri

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,29 @@
 
 - keep in README.md a living documentation of the directory and files structure
 - currently we don't have tests... but that will change in the future
+
+## Default Javascript File
+
+- `use strict`
+- use ES6 classes
+
+```js
+"use strict";
+
+import React from "react";
+
+
+export default class MyClass extends React.Component {
+  static displayName = "MyClass";
+
+  constructor(props) {
+    super(props);
+    this.state = {count: props.initialCount};
+  }
+
+  render() {
+    return <div className="my-class">
+    </div>;
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "clean": "rm -rf build",
     "postinstall": "npm run build"
   },
-  "cacheDirectories": ["node_modules"],
+  "cacheDirectories": [
+    "node_modules"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/infoeducatie/infoeducatie-react.git"
@@ -31,7 +33,7 @@
     "autoprefixer-loader": "^2.0.0",
     "babel-core": "^4.7.8",
     "babel-eslint": "^2.0.2",
-    "babel-loader": "^4.1.0",
+    "babel-loader": "^5.3.1",
     "coveralls": "^2.11.2",
     "css-loader": "^0.15.1",
     "eslint": "^0.18.0",

--- a/src/components/edition-selector.jsx
+++ b/src/components/edition-selector.jsx
@@ -1,0 +1,44 @@
+"use strict";
+
+import Ajax from "../lib/ajax"
+import {Input} from "react-bootstrap";
+import React from "react";
+
+
+export default class EditionSelector extends React.Component {
+  static displayName = "EditionSelector";
+  static propTypes = {
+    currentEditionId: React.PropTypes.number,
+    onCallback: React.PropTypes.func.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      editions: []
+    };
+  }
+
+  componentDidMount() {
+    Ajax("editions.json", (data) => {
+      this.setState({ editions: data });
+    });
+  }
+
+  render = () => {
+    return <Input type="select" onChange={this.onEditionChange}>
+      {this.state.editions.map((edition) => {
+        return <option key={edition.id}
+                       value={edition.id}>
+          Ediția {edition.year}
+        </option>;
+      })}
+    </Input>
+  }
+
+  onEditionChange(event) {
+    let id = parseInt(event.target.value);
+    this.setState({ selectedEditionId: id });
+    this.props.onCallback(id);
+  }
+}

--- a/src/components/edition-selector.jsx
+++ b/src/components/edition-selector.jsx
@@ -8,25 +8,34 @@ import React from "react";
 export default class EditionSelector extends React.Component {
   static displayName = "EditionSelector";
   static propTypes = {
-    currentEditionId: React.PropTypes.number,
     onCallback: React.PropTypes.func.isRequired
   };
 
   constructor(props) {
     super(props);
     this.state = {
-      editions: []
+      editions: [],
+      selectedEditionId: 0
     };
   }
 
   componentDidMount() {
     Ajax("editions.json", (data) => {
-      this.setState({ editions: data });
+      let currentEdition = _.find(data, (edition) => {
+        return edition.current === true;
+      });
+
+      this.setState({
+        editions: data,
+        selectedEditionId: currentEdition.id
+      });
     });
   }
 
   render = () => {
-    return <Input type="select" onChange={this.onEditionChange}>
+    return <Input type="select"
+                  onChange={this.onEditionChange}
+                  value={this.state.selectedEditionId}>
       {this.state.editions.map((edition) => {
         return <option key={edition.id}
                        value={edition.id}>
@@ -36,7 +45,7 @@ export default class EditionSelector extends React.Component {
     </Input>
   }
 
-  onEditionChange(event) {
+  onEditionChange = (event) => {
     let id = parseInt(event.target.value);
     this.setState({ selectedEditionId: id });
     this.props.onCallback(id);

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Router from "react-router";
-import { Navbar, Nav, NavItem, Row, Col, Thumbnail, Grid, NavItem } from "react-bootstrap";
+import { Navbar, Nav, NavItem, Row, Col, Thumbnail, Grid } from "react-bootstrap";
 import { NavItemLink } from "react-router-bootstrap";
 
 let { Route, Link, RouteHandler } = Router; // eslint-disable-line

--- a/src/components/talks.jsx
+++ b/src/components/talks.jsx
@@ -100,7 +100,7 @@ export default React.createClass({
         {this.state.talks.map(this.renderSeminar)}
       </Grid>
    </div>;
-  }
+  },
 
   onEditionChange(editionId) {
     // TODO @palcu: implement this

--- a/src/components/talks.jsx
+++ b/src/components/talks.jsx
@@ -93,8 +93,7 @@ export default React.createClass({
       <Grid>
         <Row>
           <Col>
-            <EditionSelector currentEditionId={this.props.edition.id}
-                             onCallback={this.onEditionChange} />
+            <EditionSelector onCallback={this.onEditionChange} />
           </Col>
         </Row>
         {this.state.talks.map(this.renderSeminar)}
@@ -103,6 +102,6 @@ export default React.createClass({
   },
 
   onEditionChange(editionId) {
-    // TODO @palcu: implement this
+    console.log(editionId)
   }
 });

--- a/src/components/talks.jsx
+++ b/src/components/talks.jsx
@@ -100,7 +100,7 @@ export default React.createClass({
         {this.state.talks.map(this.renderSeminar)}
       </Grid>
    </div>;
-  }.
+  }
 
   onEditionChange(editionId) {
     // TODO @palcu: implement this

--- a/src/components/talks.jsx
+++ b/src/components/talks.jsx
@@ -1,15 +1,14 @@
 "use strict";
 
 import $ from "jquery";
-import React from "react";
-
 import ctx from "classnames";
 import {Grid, Row, Col} from "react-bootstrap";
-
-import Header from "./header";
+import React from "react";
 
 import "../main.less";
 import DefaultAvatar from "../../assets/img/jury/default.png";
+import EditionSelector from  "./edition-selector";
+import Header from "./header";
 
 
 export default React.createClass({
@@ -92,8 +91,18 @@ export default React.createClass({
         </Grid>
       </div>
       <Grid>
+        <Row>
+          <Col>
+            <EditionSelector currentEditionId={this.props.edition.id}
+                             onCallback={this.onEditionChange} />
+          </Col>
+        </Row>
         {this.state.talks.map(this.renderSeminar)}
       </Grid>
    </div>;
+  }.
+
+  onEditionChange(editionId) {
+    // TODO @palcu: implement this
   }
 });

--- a/src/lib/ajax.js
+++ b/src/lib/ajax.js
@@ -1,0 +1,20 @@
+import $ from "jquery";
+
+export default function(endpoint, success=()=>{}, accessToken=null,
+                        error=()=>{}, method="GET") {
+  let headers = {};
+
+  if (accessToken) {
+    headers = {
+      Authorization: accessToken
+    };
+  }
+
+  $.ajax({
+    method: method,
+    url: window.config.API_URL + endpoint,
+    headers: headers,
+    success: success,
+    error: error
+  })
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -60,6 +60,7 @@ let App = React.createClass({
   render() {
     return <div className="main">
       <RouteHandler current={this.state.current}
+                    edition={this.state.current.edition}
                     user={this.state.current.user}
                     registration={this.state.current.registration}
                     refreshCurrent={this.getCurrent}

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -39,7 +39,16 @@ module.exports = {
   // Transform source code using Babel and React Hot Loader
   module: {
     loaders: [
-      { test: /\.jsx?$/, exclude: /node_modules/, loaders: ["react-hot", "babel-loader"]},
+      { test: /\.jsx?$/, exclude: /node_modules/, loader: "react-hot" },
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: "babel-loader",
+        query: {
+          optional: ["es7.classProperties"],
+          stage: 0
+        }
+      },
       { test: /\.png$/, loader: "url-loader?limit=10000&minetype=image/png" },
       { test: /\.jpg$/, loader: "url-loader?limit=10000&minetype=image/jpg" },
       { test: /\.gif$/, loader: "url-loader?limit=10000&minetype=image/gif" },

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -13,7 +13,7 @@ var webpack = require("webpack");
 module.exports = {
 
   // Efficiently evaluate modules with source maps
-  devtool: "eval",
+  devtool: "source-map",
 
   // Set entry point to ./src/main and include necessary files for hot load
   entry:  [

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -13,7 +13,8 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.jsx?$/, exclude: /node_modules/, loader: "babel-loader" },
+      { test: /\.jsx?$/, exclude: /node_modules/, loader: "babel-loader",
+        query: {optional: ["es7.classProperties"], stage: 0} },
       { test: /\.png$/, loader: "url-loader?limit=10000&minetype=image/png" },
       { test: /\.gif$/, loader: "url-loader?limit=10000&minetype=image/gif" },
       { test: /\.jpg$/, loader: "url-loader?limit=10000&minetype=image/jpg" },


### PR DESCRIPTION
In acest moment se poate adauga un singur speaker la fiecare seminar. Dupa PR https://github.com/infoeducatie/infoeducatie-api/pull/121 se vor putea adauga mai multi. Trebuie suportat asta in UI.

De asemenea trebuie adaugat suport pentru editiile anterioare.
- [ ] Lista cu editiile https://github.com/infoeducatie/infoeducatie-api/pull/122
- [ ] Se actualizeaza anul in header la schimbarea editiei
- [ ] Se actualizeaza lista de seminarii la schimbarea editiei
